### PR TITLE
Key management

### DIFF
--- a/docs/ref.md
+++ b/docs/ref.md
@@ -184,3 +184,50 @@ Returns `-1` if a value for the key does not expire.
 Returns `-2` if a value for the key has expired, or has not been set.
 
 ---
+
+#### *@cache.get_all_keys() -> list[str]*
+
+Get all keys that exist in the cache for currently valid cache items.
+Returns a list of cache keys in naturally sorted order.
+
+---
+
+#### *@cache.find_keys_starting_with(...) -> list[str]*
+- pattern: str – The pattern to match at the start of the key.
+
+Find keys that start with the given pattern.
+Matching follows the SQLite specification for the `LIKE` operator, so
+it will match `'A'` to `'a'`, but not `'Ä'` to `'ä'`.
+Returns a list of matching cache keys in sort order.
+Will only return keys that exist in the cache for currently valid cache items.
+
+---
+
+#### *@cache.find_matching_keys(...) -> list[str]*
+- pattern: str – The pattern to find in matching keys.
+
+Find keys that contain the given pattern anywhere in the string.
+Matching follows the SQLite specification for the `LIKE` operator, so
+it will match `'A'` to `'a'`, but not `'Ä'` to `'ä'`.
+Returns a list of matching cache keys in sort order.
+Will only return keys that exist in the cache for currently valid cache items.
+
+---
+
+#### *@cache.clear_keys_starting_with(...) -> None*
+- pattern: str – The pattern to match at the start of the key.
+
+Clear all keys from the cache that start with the given pattern.
+Matching follows the SQLite specification for the `LIKE` operator, so
+it will match `'A'` to `'a'`, but not `'Ä'` to `'ä'`.
+
+---
+
+#### *@cache.clear_matching_keys(...) -> None*
+- pattern: str – The pattern to find in matching keys.
+
+Clear all keys from the cache that contain the given pattern anywhere in the string.
+Matching follows the SQLite specification for the `LIKE` operator, so
+it will match `'A'` to `'a'`, but not `'Ä'` to `'ä'`.
+
+---

--- a/docs/ref.md
+++ b/docs/ref.md
@@ -192,6 +192,14 @@ Returns a list of cache keys in naturally sorted order.
 
 ---
 
+#### *@cache.find_matching_keys(...) -> list[str]*
+- like_match_pattern: str – A string formatted for SQL `LIKE` operator comparison.
+
+Find keys that match a SQL `LIKE` pattern.
+Returns a list of matching keys.
+
+---
+
 #### *@cache.find_keys_starting_with(...) -> list[str]*
 - pattern: str – The pattern to match at the start of the key.
 
@@ -203,7 +211,18 @@ Will only return keys that exist in the cache for currently valid cache items.
 
 ---
 
-#### *@cache.find_matching_keys(...) -> list[str]*
+#### *@cache.find_keys_ending_with(...) -> list[str]*
+- pattern: str – The pattern to match at the end of the key.
+
+Find keys that end with the given pattern.
+Matching follows the SQLite specification for the `LIKE` operator, so
+it will match `'A'` to `'a'`, but not `'Ä'` to `'ä'`.
+Returns a list of matching cache keys in sort order.
+Will only return keys that exist in the cache for currently valid cache items.
+
+---
+
+#### *@cache.find_keys_containing(...) -> list[str]*
 - pattern: str – The pattern to find in matching keys.
 
 Find keys that contain the given pattern anywhere in the string.
@@ -211,6 +230,15 @@ Matching follows the SQLite specification for the `LIKE` operator, so
 it will match `'A'` to `'a'`, but not `'Ä'` to `'ä'`.
 Returns a list of matching cache keys in sort order.
 Will only return keys that exist in the cache for currently valid cache items.
+
+---
+
+#### *@cache.clear_matching_keys(...) -> None*
+- like_match_pattern: str – A string formatted for SQL `LIKE` operator comparison.
+
+Clear keys that match a SQL `LIKE` pattern.
+Matching follows the SQLite specification for the `LIKE` operator, so
+it will match `'A'` to `'a'`, but not `'Ä'` to `'ä'`.
 
 ---
 
@@ -223,10 +251,19 @@ it will match `'A'` to `'a'`, but not `'Ä'` to `'ä'`.
 
 ---
 
-#### *@cache.clear_matching_keys(...) -> None*
+#### *@cache.clear_keys_ending_with(...) -> None*
+- pattern: str – The pattern to match at the end of the key.
+
+Clear all keys from the cache that end with the given pattern.
+Matching follows the SQLite specification for the `LIKE` operator, so
+it will match `'A'` to `'a'`, but not `'Ä'` to `'ä'`.
+
+---
+
+#### *@cache.clear_keys_containing(...) -> None*
 - pattern: str – The pattern to find in matching keys.
 
-Clear all keys from the cache that contain the given pattern anywhere in the string.
+Clear keys that contain the given pattern anywhere in the string.
 Matching follows the SQLite specification for the `LIKE` operator, so
 it will match `'A'` to `'a'`, but not `'Ä'` to `'ä'`.
 

--- a/sqlite3_cache/cache.py
+++ b/sqlite3_cache/cache.py
@@ -565,8 +565,8 @@ class Cache:
     def find_keys_starting_with(self, pattern: str) -> List[str]:
         """
         Find keys that start with the given pattern.
-        Matching follows the SQLite specification for LIKE, so it is case-insensitive
-        to match 'A' to 'a', but case-sensitive to match 'Ä' to 'ä'.
+        Matching follows the SQLite specification for the LIKE operator, so
+        it will match 'A' to 'a', but not 'Ä' to 'ä'.
         Will only return keys that exist in the cache for currently valid cache items.
 
         :param pattern: The pattern to match at the start of the key.
@@ -583,8 +583,8 @@ class Cache:
     def find_matching_keys(self, pattern: str) -> List[str]:
         """
         Find keys that contain the given pattern anywhere in the string.
-        Matching follows the SQLite specification for LIKE, so it is case-insensitive
-        to match 'A' to 'a', but case-sensitive to match 'Ä' to 'ä'.
+        Matching follows the SQLite specification for the LIKE operator, so
+        it will match 'A' to 'a', but not 'Ä' to 'ä'.
         Will only return keys that exist in the cache for currently valid cache items.
 
         :param pattern: The pattern to find in matching keys.
@@ -601,8 +601,8 @@ class Cache:
     def clear_keys_starting_with(self, pattern: str) -> None:
         """
         Clear all keys from the cache that start with the given pattern.
-        Matching follows the SQLite specification for LIKE, so it is case-insensitive
-        to match 'A' to 'a', but case-sensitive to match 'Ä' to 'ä'.
+        Matching follows the SQLite specification for the LIKE operator, so
+        it will match 'A' to 'a', but not 'Ä' to 'ä'.
 
         :param pattern: The pattern to match at the start of the key.
         """
@@ -612,9 +612,9 @@ class Cache:
 
     def clear_matching_keys(self, pattern: str) -> None:
         """
-        Clear all keys that contain the given pattern anywhere in the string.
-        Matching follows the SQLite specification for LIKE, so it is case-insensitive
-        to match 'A' to 'a', but case-sensitive to match 'Ä' to 'ä'.
+        Clear all keys from the cache that contain the given pattern anywhere in the string.
+        Matching follows the SQLite specification for the LIKE operator, so
+        it will match 'A' to 'a', but not 'Ä' to 'ä'.
 
         :param pattern: The pattern to find in matching keys.
         """

--- a/sqlite3_cache/cache.py
+++ b/sqlite3_cache/cache.py
@@ -552,7 +552,6 @@ class Cache:
     def get_all_keys(self) -> List[str]:
         """
         Get all keys that exist in the cache for currently valid cache items.
-
         :return: List of cache keys in sort order.
         """
         fetched: List[Tuple[str, Any]] = self._con.execute(self._get_keys_sql).fetchall()
@@ -568,7 +567,6 @@ class Cache:
         Matching follows the SQLite specification for the LIKE operator, so
         it will match 'A' to 'a', but not 'Ä' to 'ä'.
         Will only return keys that exist in the cache for currently valid cache items.
-
         :param pattern: The pattern to match at the start of the key.
         :return: List of matching cache keys in sort order.
         """
@@ -586,7 +584,6 @@ class Cache:
         Matching follows the SQLite specification for the LIKE operator, so
         it will match 'A' to 'a', but not 'Ä' to 'ä'.
         Will only return keys that exist in the cache for currently valid cache items.
-
         :param pattern: The pattern to find in matching keys.
         :return: List of matching cache keys in sort order.
         """
@@ -603,7 +600,6 @@ class Cache:
         Clear all keys from the cache that start with the given pattern.
         Matching follows the SQLite specification for the LIKE operator, so
         it will match 'A' to 'a', but not 'Ä' to 'ä'.
-
         :param pattern: The pattern to match at the start of the key.
         """
         data = {"pattern": f"{''}{pattern}%"}
@@ -615,7 +611,6 @@ class Cache:
         Clear all keys from the cache that contain the given pattern anywhere in the string.
         Matching follows the SQLite specification for the LIKE operator, so
         it will match 'A' to 'a', but not 'Ä' to 'ä'.
-
         :param pattern: The pattern to find in matching keys.
         """
         data = {"pattern": f"{'%'}{pattern}%"}

--- a/sqlite3_cache/cache.py
+++ b/sqlite3_cache/cache.py
@@ -72,7 +72,7 @@ class Cache:
     _delete_many_sql = "DELETE FROM cache WHERE key IN ({});"
     _get_keys_sql = "SELECT key, exp FROM cache ORDER BY key ASC;"
     _find_matching_keys_sql = "SELECT key, exp FROM cache WHERE key LIKE :pattern ORDER BY key ASC;"
-    _clear_starting_with_sql = "DELETE FROM cache WHERE key LIKE :pattern;"
+    _clear_keys_matching_sql = "DELETE FROM cache WHERE key LIKE :pattern;"
 
     def __init__(  # noqa: PLR0913
         self,
@@ -570,7 +570,7 @@ class Cache:
         :param pattern: The pattern to match at the start of the key.
         :return: List of matching cache keys in sort order.
         """
-        data = {"pattern": f"{''}{pattern}%"}
+        data = {"pattern": f"{pattern}%"}
         fetched: List[Tuple[str, Any]] = self._con.execute(self._find_matching_keys_sql, data).fetchall()
 
         if not fetched:
@@ -587,7 +587,7 @@ class Cache:
         :param pattern: The pattern to find in matching keys.
         :return: List of matching cache keys in sort order.
         """
-        data = {"pattern": f"{'%'}{pattern}%"}
+        data = {"pattern": f"%{pattern}%"}
         fetched: List[Tuple[str, Any]] = self._con.execute(self._find_matching_keys_sql, data).fetchall()
 
         if not fetched:
@@ -602,8 +602,8 @@ class Cache:
         it will match 'A' to 'a', but not 'Ä' to 'ä'.
         :param pattern: The pattern to match at the start of the key.
         """
-        data = {"pattern": f"{''}{pattern}%"}
-        self._con.execute(self._clear_starting_with_sql, data)
+        data = {"pattern": f"{pattern}%"}
+        self._con.execute(self._clear_keys_matching_sql, data)
         self._con.commit()
 
     def clear_matching_keys(self, pattern: str) -> None:
@@ -613,6 +613,6 @@ class Cache:
         it will match 'A' to 'a', but not 'Ä' to 'ä'.
         :param pattern: The pattern to find in matching keys.
         """
-        data = {"pattern": f"{'%'}{pattern}%"}
-        self._con.execute(self._clear_starting_with_sql, data)
+        data = {"pattern": f"%{pattern}%"}
+        self._con.execute(self._clear_keys_matching_sql, data)
         self._con.commit()

--- a/sqlite3_cache/cache.py
+++ b/sqlite3_cache/cache.py
@@ -529,7 +529,8 @@ class Cache:
     def _filter_key_result_list(self, unfiltered: List[Tuple[str, Any]]) -> List[str]:
         """
         Filters key result list to only those keys for cache items that are still alive,
-        and purges expired items from the cache
+        and purges expired items from the cache.
+
         :param unfiltered: A list of key and expiration tuples
         :return: A filtered list of keys
         """
@@ -552,6 +553,7 @@ class Cache:
     def get_all_keys(self) -> List[str]:
         """
         Get all keys that exist in the cache for currently valid cache items.
+
         :return: List of cache keys in sort order.
         """
         fetched: List[Tuple[str, Any]] = self._con.execute(self._get_keys_sql).fetchall()
@@ -567,6 +569,7 @@ class Cache:
         Matching follows the SQLite specification for the LIKE operator, so
         it will match 'A' to 'a', but not 'Ä' to 'ä'.
         Will only return keys that exist in the cache for currently valid cache items.
+
         :param pattern: The pattern to match at the start of the key.
         :return: List of matching cache keys in sort order.
         """
@@ -584,6 +587,7 @@ class Cache:
         Matching follows the SQLite specification for the LIKE operator, so
         it will match 'A' to 'a', but not 'Ä' to 'ä'.
         Will only return keys that exist in the cache for currently valid cache items.
+
         :param pattern: The pattern to find in matching keys.
         :return: List of matching cache keys in sort order.
         """
@@ -600,6 +604,7 @@ class Cache:
         Clear all keys from the cache that start with the given pattern.
         Matching follows the SQLite specification for the LIKE operator, so
         it will match 'A' to 'a', but not 'Ä' to 'ä'.
+
         :param pattern: The pattern to match at the start of the key.
         """
         data = {"pattern": f"{pattern}%"}
@@ -611,6 +616,7 @@ class Cache:
         Clear all keys from the cache that contain the given pattern anywhere in the string.
         Matching follows the SQLite specification for the LIKE operator, so
         it will match 'A' to 'a', but not 'Ä' to 'ä'.
+
         :param pattern: The pattern to find in matching keys.
         """
         data = {"pattern": f"%{pattern}%"}

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -468,6 +468,24 @@ def test_cache_find_matching_keys(cache):
     assert cache.find_matching_keys("foo") == ["bar.foo", "foo.bar"]
 
 
+def test_clear_keys_starting_with(cache):
+    cache.set("foo.bar", "bar", timeout=-1)
+    cache.set("foo.foo", "foobar", timeout=-1)
+    cache.set("bar.foo", "barfoo", timeout=-1)
+    cache.set("bar.bar", "barbar", timeout=-1)
+    cache.clear_keys_starting_with("bar")
+    assert cache.get_all_keys() == ["foo.bar", "foo.foo"]
+
+
+def test_clear_matching_keys(cache):
+    cache.set("foo.bar", "bar", timeout=-1)
+    cache.set("foo.foo", "foobar", timeout=-1)
+    cache.set("bar.foo", "barfoo", timeout=-1)
+    cache.set("bar.bar", "barbar", timeout=-1)
+    cache.clear_matching_keys("bar")
+    assert cache.get_all_keys() == ["foo.foo"]
+
+
 @pytest.mark.skip("this is a benchmark")
 def test_speed():
     start = perf_counter_ns()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -395,6 +395,18 @@ def test_cache_ttl_many__expired(cache):
         assert cache.ttl_many(["foo", "one"]) == {"foo": -2, "one": -2}
 
 
+def test_cache_get_all_keys(cache):
+    cache.set("foo", "bar", timeout=100)
+    cache.set("one", "two", timeout=1)
+    cache.set("three", "four", timeout=1)
+    cache.set("biz", "buzz", timeout=100)
+    # keys are sorted in order
+    assert cache.get_all_keys() == ["biz", "foo", "one", "three"]
+    sleep(1.1)
+    # expired keys are not returned
+    assert cache.get_all_keys() == ["biz", "foo"]
+
+
 @pytest.mark.skip("this is a benchmark")
 def test_speed():
     start = perf_counter_ns()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -397,6 +397,10 @@ def test_cache_ttl_many__expired(cache):
 
 
 def test_cache_get_all_keys(cache):
+    # empty cache returns empty list
+    assert cache.get_all_keys() == []
+
+    # non-empty cache returns some items
     cache.set("foo", "bar", timeout=100)
     cache.set("one", "two", timeout=1)
     cache.set("three", "four", timeout=1)
@@ -425,6 +429,9 @@ def test__filter_key_result_list(cache):
 
 
 def test_find_matching_keys(cache):
+    # empty cache returns empty list
+    assert cache.find_matching_keys("%foo%") == []
+
     cache.set("foo.bar", "bar", timeout=-1)
     cache.set("foo.foo", "foobar", timeout=-1)
     cache.set("bar.foo", "barfoo", timeout=-1)
@@ -433,6 +440,7 @@ def test_find_matching_keys(cache):
     assert cache.find_matching_keys("foo%") == ["foo.bar", "foo.foo"]
     assert cache.find_matching_keys("%foo") == ["bar.foo", "foo.foo"]
     assert cache.find_matching_keys("%foo%") == ["bar.foo", "foo.bar", "foo.foo"]
+    assert cache.find_matching_keys("%biz%") == []
 
 
 def test_cache_find_keys_starting_with(cache):
@@ -443,6 +451,7 @@ def test_cache_find_keys_starting_with(cache):
     # keys are returned sorted in order
     assert cache.find_keys_starting_with("foo") == ["foo.bar", "foo.foo"]
     assert cache.find_keys_starting_with("bar") == ["bar.bar", "bar.foo"]
+    assert cache.find_keys_starting_with("biz") == []
 
     cache.clear()
 
@@ -474,6 +483,7 @@ def test_cache_find_keys_ending_with(cache):
     # keys are returned sorted in order
     assert cache.find_keys_ending_with("foo") == ["bar.foo", "foo.foo"]
     assert cache.find_keys_ending_with("bar") == ["bar.bar", "foo.bar"]
+    assert cache.find_keys_ending_with("biz") == []
 
     cache.clear()
 
@@ -505,6 +515,7 @@ def test_cache_find_keys_containing(cache):
     # keys are returned sorted in order
     assert cache.find_keys_containing("biz") == ["bar.biz.bar", "biz.bar.foo", "foo.bar.biz"]
     assert cache.find_keys_containing("foo") == ["biz.bar.foo", "foo.bar.biz", "foo.foo.bar"]
+    assert cache.find_keys_containing("bazz") == []
 
     cache.clear()
 
@@ -528,6 +539,9 @@ def test_cache_find_keys_containing(cache):
 
 
 def test_clear_matching_keys(cache):
+    # empty cache should clear just fine
+    assert cache.get_all_keys() == []
+
     cache.set("foo.bar", "bar", timeout=-1)
     cache.set("foo.foo", "foobar", timeout=-1)
     cache.set("bar.foo", "barfoo", timeout=-1)
@@ -550,6 +564,14 @@ def test_clear_matching_keys(cache):
     cache.set("bar.bar", "barbar", timeout=-1)
     cache.clear_matching_keys("%foo%")
     assert cache.get_all_keys() == ["bar.bar"]
+    cache.clear()
+
+    cache.set("foo.bar", "bar", timeout=-1)
+    cache.set("foo.foo", "foobar", timeout=-1)
+    cache.set("bar.foo", "barfoo", timeout=-1)
+    cache.set("bar.bar", "barbar", timeout=-1)
+    cache.clear_matching_keys("")
+    assert cache.get_all_keys() == ["bar.bar", "bar.foo", "foo.bar", "foo.foo"]
 
 
 def test_clear_keys_starting_with(cache):


### PR DESCRIPTION
[//]: # "Please read `CONTRIBUTING.md` before opening a pull request."

# Key Management updates
[//]: # "Describe the changes in this pull request here."

Added methods for key management functions, particularly to support namespaced keys:

- `cache.get_all_keys()` returns a list of all keys
- `cache.find_keys_starting_with(pattern)` returns a list of keys starting with the pattern
- `cache.find_matching_keys(pattern)` returns a list of keys containing the pattern anywhere
- `cache.clear_keys_starting_with(pattern)` clears all keys starting with the pattern
- `cache.clear_matching_keys(pattern)` clears all keys containing the pattern anywhere


